### PR TITLE
Apply suggestions from community

### DIFF
--- a/http451.permissions.yml
+++ b/http451.permissions.yml
@@ -1,7 +1,7 @@
-configure_http451:
+configure http451:
   title: 'Module Settings'
   description: 'Configuration permissions for administration'
 
-access_content:
+use http451:
   title: 'Block Page'
   description: 'This will allow http451 module to block user access to certain pages as per RFC 7725'

--- a/http451.services.yml
+++ b/http451.services.yml
@@ -3,3 +3,4 @@ services:
     class: Drupal\http451\EventSubscriber\Http451RedirectSubscriber
     tags:
       - { name: event_subscriber }
+    arguments: ['@config.factory', '@entity.manager']

--- a/src/Form/Http451Form.php
+++ b/src/Form/Http451Form.php
@@ -33,7 +33,7 @@ class Http451Form extends ConfigFormBase {
     $form = parent::buildForm($form, $form_state);
 
     // Default parameters.
-    $config = \Drupal::config('http451.settings');
+    $config = $this->config('http451.settings');
 
     // Get api key if already set.
     $api_key = $config->get('geoip_api_key');
@@ -66,14 +66,12 @@ class Http451Form extends ConfigFormBase {
    * Form submission callback.
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    // The Messenger service.
+    $config = $this->config('http451.settings');
     $values = $form_state->getValues();
 
-    $messenger = \Drupal::messenger();
+    $this->config->set('geoip_api_key', $values['geoip_api_key'])->save();
 
-    \Drupal::configFactory()->getEditable('http451.settings')->set('geoip_api_key', $values['geoip_api_key'])->save();
-
-    $messenger->addStatus($this->t('Your API Key key has been set.'));
+    $this->messenger->addStatus($this->t('Your API Key key has been set.'));
   }
 
 }


### PR DESCRIPTION
I've made the changes suggested in https://www.drupal.org/project/projectapplications/issues/3036543 except for:

	getIpAddressOriginCountry(): Do not use cURL directly, use Drupal HTTP client API (Guzzle). That way global proxy settings and other configuration for outgoing HTTP requests are respected.

	getIpAddressOriginCountry(): this will generate PHP warnings if the response is not valid JSON and you will then return a null country. Error handling is missing here.

Please test before merging.